### PR TITLE
Add session duration limits

### DIFF
--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -304,12 +304,16 @@ function storage:CreateSession( steamID, sessionStart, sessionEnd, sessionDurati
 
     logger:debug( "[" .. tostring( steamID ) .. "] Creating " .. tostring( sessionsCount ) .. " sessions to accomodate duration of: " .. tostring( sessionDuration ) )
 
+
     local function addSession( duration, newStart, newEnd )
         local debugLine = "Queueing new session of duration: %d ( start: %d | end: %d )"
         logger:debug( string.format( debugLine, duration, newStart, newEnd ) )
 
+        local newSessionTransaction = self:InitTransaction()
         local newSession = self:Prepare( "newSession", nil, steamID, newStart, newEnd, duration )
-        newSession:start()
+
+        newSessionTransaction:addQuery( newSession )
+        newSessionTransaction:start()
     end
 
     for i = 1, sessionsCount do

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -311,7 +311,7 @@ function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, ses
 
     local function addSession( duration, newStart, newEnd )
         local debugLine = "Queueing new session of duration: %d ( start: %d | end: %d )"
-        logger.debug( string.format( debugLine, duration, newStart, newEnd ) )
+        logger:debug( string.format( debugLine, duration, newStart, newEnd ) )
 
         local newSession = self:Prepare( "newSession", nil, steamID, newStart, newEnd, duration )
         transaction:addQuery( newSession )

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -299,7 +299,7 @@ end
 
 function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, sessionDuration )
     local maxDuration = self.MAX_SESSION_DURATION
-    local sessionsCount = math.ceil( maxDuration / sessionDuration )
+    local sessionsCount = math.ceil( sessionDuration / maxDuration )
     if sessionsCount == math.huge then sessionsCount = 1 end
 
     logger:debug( "[" .. tostring( steamID ) .. "] Creating " .. tostring( sessionsCount ) .. " sessions to accomodate duration of: " .. tostring( sessionDuration ) )
@@ -320,7 +320,7 @@ function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, ses
     for i = 1, sessionsCount do
         local usedDuration = maxDuration * ( i - 1 )
 
-        local newDuration = sessionDuration - usedDuration
+        local newDuration = math.min( sessionDuration - usedDuration, maxDuration )
         local newStart = sessionStart + usedDuration
         local newEnd = newStart + newDuration
 

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -297,24 +297,19 @@ function storage:GetTotalTime( steamID, callback )
     query:start()
 end
 
-function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, sessionDuration )
+function storage:CreateSession( steamID, sessionStart, sessionEnd, sessionDuration )
     local maxDuration = self.MAX_SESSION_DURATION
     local sessionsCount = math.ceil( sessionDuration / maxDuration )
     sessionsCount = math.max( 1, sessionsCount )
 
     logger:debug( "[" .. tostring( steamID ) .. "] Creating " .. tostring( sessionsCount ) .. " sessions to accomodate duration of: " .. tostring( sessionDuration ) )
 
-    local transaction = self:InitTransaction()
-    transaction.onSuccess = function()
-        if callback then callback() end
-    end
-
     local function addSession( duration, newStart, newEnd )
         local debugLine = "Queueing new session of duration: %d ( start: %d | end: %d )"
         logger:debug( string.format( debugLine, duration, newStart, newEnd ) )
 
         local newSession = self:Prepare( "newSession", nil, steamID, newStart, newEnd, duration )
-        transaction:addQuery( newSession )
+        newSession:start()
     end
 
     for i = 1, sessionsCount do
@@ -326,8 +321,6 @@ function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, ses
 
         addSession( newDuration, newStart, newEnd )
     end
-
-    transaction:start()
 end
 
 -- Takes a player, a session start timestamp, and a callback, then:

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -103,7 +103,7 @@ function storage:GetMaxSessionTime( callback )
         return MAX_SESSION_DURATIONS[column][signed and "signed" or "unsigned"]
     end
 
-    query.onSucces = function( _, data )
+    query.onSuccess = function( _, data )
         if data then
             logger:debug( "Session duration query result", data )
         end

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -116,7 +116,7 @@ function storage:GetMaxSessionTime( callback )
     query:start()
 end
 
-function storage:SetMaxSessionTime()
+function storage:CacheMaxSessionDuration()
     self:GetMaxSessionTime(
         function( maxSessionTime )
             logger:debug( "Setting max session duration to: " .. maxSessionTime )
@@ -246,7 +246,7 @@ function storage.database:onConnected()
     transaction:addQuery( storage:SessionCleanupQuery() )
 
     transaction.onSuccess = function()
-        storage:SetMaxSessionTime()
+        storage:CacheMaxSessionDuration()
         storage:PrepareStatements()
     end
 
@@ -300,7 +300,7 @@ end
 function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, sessionDuration )
     local maxDuration = self.MAX_SESSION_DURATION
     local sessionsCount = math.ceil( sessionDuration / maxDuration )
-    if sessionsCount == math.huge then sessionsCount = 1 end
+    sessionsCount = math.max( 1, sessionsCount )
 
     logger:debug( "[" .. tostring( steamID ) .. "] Creating " .. tostring( sessionsCount ) .. " sessions to accomodate duration of: " .. tostring( sessionDuration ) )
 

--- a/lua/cfc_time/server/storage_options/sqlite.lua
+++ b/lua/cfc_time/server/storage_options/sqlite.lua
@@ -157,7 +157,7 @@ function storage:PlayerInit( ply, sessionStart, callback )
 
     sql.Begin()
 
-    local firstVisit = self:QueryGetUser( steamID ) == nil
+    local isFirstVisit = self:QueryGetUser( steamID ) == nil
     self:QueryCreateUser( steamID )
     self:QueryCreateSession( steamID, sessionStart, SQL_NULL, 0 )
 
@@ -166,7 +166,7 @@ function storage:PlayerInit( ply, sessionStart, callback )
     local sessionID = tonumber( self:QueryLatestSessionId()[1]["last_insert_rowid()"] )
 
     local response = {
-        firstVisit = firstVisit,
+        isFirstVisit = isFirstVisit,
         sessionID = sessionID
     }
 

--- a/lua/cfc_time/server/storage_options/sqlite.lua
+++ b/lua/cfc_time/server/storage_options/sqlite.lua
@@ -144,10 +144,8 @@ function storage:GetTotalTime( steamID, callback )
     return sum
 end
 
-function storage:CreateSession( callback, steamID, sessionStart, sessionEnd, duration )
-    local newSession = self:QueryCreateSession( steamID, sessionStart, sessionEnd, duration )
-
-    if callback then callback( newSession ) end
+function storage:CreateSession( steamID, sessionStart, sessionEnd, duration )
+    self:QueryCreateSession( steamID, sessionStart, sessionEnd, duration )
 end
 
 function storage:PlayerInit( ply, sessionStart, callback )

--- a/lua/cfc_time/server/time_tracking.lua
+++ b/lua/cfc_time/server/time_tracking.lua
@@ -107,7 +107,7 @@ function ctime:initPlayer( ply )
     local now = getNow()
     local steamID = ply:SteamID64()
 
-    local function setupPly( totalTime, firstVisit )
+    local function setupPly( totalTime, isFirstVisit )
         local sessionTotalTime = totalTime + ( getNow() - now )
 
         local initialTime = {
@@ -122,7 +122,7 @@ function ctime:initPlayer( ply )
             end
         }
 
-        hook.Run( "CFC_Time_PlayerInitialTime", ply, firstVisit, initialTime )
+        hook.Run( "CFC_Time_PlayerInitialTime", ply, isFirstVisit, initialTime )
         sessionTotalTime = sessionTotalTime + initialTime.seconds
 
         ctime.totalTimes[steamID] = sessionTotalTime
@@ -130,14 +130,14 @@ function ctime:initPlayer( ply )
     end
 
     storage:PlayerInit( ply, now, function( data )
-        local firstVisit = data.firstVisit
+        local isFirstVisit = data.isFirstVisit
         local sessionID = data.sessionID
 
         steamIDToPly[steamID] = ply
         ctime.sessionIDs[steamID] = sessionID
         ctime.sessions[steamID] = { joined = now }
 
-        if firstVisit then return setupPly( 0, true ) end
+        if isFirstVisit then return setupPly( 0, true ) end
 
         storage:GetTotalTime( steamID, function( total )
             setupPly( total, false )

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -51,8 +51,8 @@ if SERVER then
         return totalTime
     end
 
-    hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, firstVisit, timeStruct )
-        if not firstVisit then return end
+    hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
+        if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!")
 

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -44,7 +44,7 @@ if SERVER then
         local sessionStart = lastVisit - totalTime
         local sessionEnd = lastVisit
 
-        CFCTime.Storage:CreateSession( nil, steamID, sessionStart, sessionEnd, totalTime )
+        CFCTime.Storage:CreateSession( steamID, sessionStart, sessionEnd, totalTime )
 
         CFCTime.Logger:info( "Player " .. ply:GetName() .. "[" .. steamID .. "] migrated from UTime with existing time of " .. totalTime )
 


### PR DESCRIPTION
We realized that the column type for session duration was too small to hold my _massive_ utime total.

An easy solution would be to change the column type to `bigint` and call it a day, but given how much time and effort we've put into making this addon performant and extensible, I figured that if a consumer wanted/needed to change the column type in the future, we may as well support it.

On top of that, the only time a session would actually be bigger than a `mediumint` is when the time gets migrated over from `utime`, so like 99.999% of sessions will be within the limits of an unsigned `mediumint`. Seemed wasteful to make all of them `bigints`.

So this is a _little_ over-engineered, but it supports the column being literally any type and will automatically create as many sessions as needed to conform with the limits.

Please pay special attention to this section: https://github.com/CFC-Servers/cfc_time/pull/20/files#diff-f2d09ccac106fdf7084c5adb275e4ca6R289-R311

It's the meat of this PR and prone to the most mistakes. Please carefully read through it and think of edge cases, potential bugs/misbehaviors, etc.


**Tested:**
```
[CFCTime] [info] Receiving PlayerInit call for: 76561198002607474
[CFCTime] [debug] PlayerInit transaction successful!
[CFCTime] [debug] NewUser last inserted index: 1
[CFCTime] [debug] [UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!
[CFCTime] [debug] [76561198002607474] Creating 7 sessions to accomodate duration of: 101667175
[CFCTime] [debug] Queueing new session of duration: 16777215 ( start: 1495353351 | end: 1512130566 )
[CFCTime] [debug] Queueing new session of duration: 16777215 ( start: 1512130566 | end: 1528907781 )
[CFCTime] [debug] Queueing new session of duration: 16777215 ( start: 1528907781 | end: 1545684996 )
[CFCTime] [debug] Queueing new session of duration: 16777215 ( start: 1545684996 | end: 1562462211 )
[CFCTime] [debug] Queueing new session of duration: 16777215 ( start: 1562462211 | end: 1579239426 )
[CFCTime] [debug] Queueing new session of duration: 16777215 ( start: 1579239426 | end: 1596016641 )
[CFCTime] [debug] Queueing new session of duration: 1003885 ( start: 1596016641 | end: 1597020526 )
[CFCTime] [info] Player Phatso[76561198002607474] migrated from UTime with existing time of 101667175
```

```
mysql> select * from sessions;
+----+---------+-------------------+------------+------------+----------+
| id | realm   | user_id           | joined     | departed   | duration |
+----+---------+-------------------+------------+------------+----------+
|  1 | cfctest | 76561198002607474 | 1598739164 |       NULL |        2 |
|  2 | cfctest | 76561198002607474 | 1495353351 | 1512130566 | 16777215 |
|  3 | cfctest | 76561198002607474 | 1512130566 | 1528907781 | 16777215 |
|  4 | cfctest | 76561198002607474 | 1528907781 | 1545684996 | 16777215 |
|  5 | cfctest | 76561198002607474 | 1545684996 | 1562462211 | 16777215 |
|  6 | cfctest | 76561198002607474 | 1562462211 | 1579239426 | 16777215 |
|  7 | cfctest | 76561198002607474 | 1579239426 | 1596016641 | 16777215 |
|  8 | cfctest | 76561198002607474 | 1596016641 | 1597020526 |  1003885 |
+----+---------+-------------------+------------+------------+----------+
```