### PR TITLE
Fix utimestart being constantly set

### DIFF
--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -85,7 +85,7 @@ if SERVER then
         ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
     end )
 
-    hook.Add( "CFC_Time_PlayerTimeUpdated", "CFC_Time_UtimeCompat", function( ply, totalTime )
+    hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, totalTime )
         ply:SetNWFloat( "TotalUTime", totalTime )
     end )
 end

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -69,7 +69,7 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
-        ply:SetNWFloat( "UTimeStart", CurTime() )
+
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!")
@@ -83,5 +83,9 @@ if SERVER then
 
     hook.Add( "CFC_Time_PlayerTimeUpdated", "CFC_Time_UtimeCompat", function( ply, totalTime )
         ply:SetNWFloat( "TotalUTime", totalTime )
+    end )
+
+    hook.Add( "PlayerInitialSpawn", "CFC_Time_UtimeCompatSetUTimeStart", function( ply )
+        ply:SetNWFloat( "UTimeStart", CurTime() )
     end )
 end

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -12,7 +12,7 @@ function plyMeta:GetUTime()
 end
 
 function plyMeta:GetUTimeStart()
-    return self:GetNWFloat( "UTimeStart", CurTime() )
+    return self:GetNWFloat( "CFC_Time_SessionStart", CurTime() )
 end
 
 function plyMeta:GetUTimeSessionTime()
@@ -69,6 +69,7 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
+        ply:SetNWFloat( "UTimeStart", CurTime() )
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!")
@@ -82,9 +83,5 @@ if SERVER then
 
     hook.Add( "CFC_Time_PlayerTimeUpdated", "CFC_Time_UtimeCompat", function( ply, totalTime )
         ply:SetNWFloat( "TotalUTime", totalTime )
-    end )
-
-    hook.Add( "PlayerInitialSpawn", "CFC_Time_UtimeCompatSetUTimeStart", function( ply )
-        ply:SetNWFloat( "UTimeStart", CurTime() )
     end )
 end

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -71,6 +71,7 @@ if SERVER then
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
         ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
+        ply:SetNWFloat( "UTimeStart", CurTime() )
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!" )

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -13,7 +13,9 @@ function plyMeta:GetUTime()
 end
 
 function plyMeta:GetUTimeStart()
-    return self:GetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
+    local now = os.time()
+    local sessionSeconds = now - self:GetNWFloat( "CFC_Time_SessionStart", now )
+    return CurTime() - sessionSeconds
 end
 
 function plyMeta:GetUTimeSessionTime()

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -69,7 +69,6 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
-
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!")

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -3,6 +3,7 @@ Utime = {}
 
 -- Addons like APromote rely on the utime_welcome convar existing for some reason?
 CreateConVar( "utime_welcome", "1", FCVAR_ARCHIVE )
+CreateConVar( "utime_enable", "1", FCVAR_ARCHIVE )
 
 local logger = CFCTime.Logger
 local plyMeta = FindMetaTable( "Player" )

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -72,7 +72,7 @@ if SERVER then
         ply:SetNWFloat( "UTimeStart", CurTime() )
         if not isFirstVisit then return end
 
-        logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!")
+        logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!" )
 
         local totalUtime = compat:MigratePlayerFromUtime( ply )
 

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -69,6 +69,7 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
+        ply:SetNWFloat( "UTimeStart", CurTime() )
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!")
@@ -82,6 +83,5 @@ if SERVER then
 
     hook.Add( "CFC_Time_PlayerTimeUpdated", "CFC_Time_UtimeCompat", function( ply, totalTime )
         ply:SetNWFloat( "TotalUTime", totalTime )
-        ply:SetNWFloat( "UTimeStart", CurTime() )
     end )
 end

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -72,8 +72,6 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
-        ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
-        ply:SetNWFloat( "UTimeStart", CurTime() )
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!" )

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -70,6 +70,8 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
+        ply:SetNWFloat( "TotalUTime", totalTime )
+        ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!" )
@@ -81,11 +83,7 @@ if SERVER then
         timeStruct.add( totalUtime )
     end )
 
-    hook.Add( "PlayerInitialSpawn", "CFC_Time_UtimeCompat", function( ply )
-        ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
-    end )
-
-    hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, totalTime )
+    hook.Add( "CFC_Time_PlayerTimeUpdated", "CFC_Time_UtimeCompat", function( ply, totalTime )
         ply:SetNWFloat( "TotalUTime", totalTime )
     end )
 end

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -70,7 +70,6 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
-        ply:SetNWFloat( "TotalUTime", totalTime )
         ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
         if not isFirstVisit then return end
 

--- a/lua/cfc_time/shared/utime_compat.lua
+++ b/lua/cfc_time/shared/utime_compat.lua
@@ -13,7 +13,7 @@ function plyMeta:GetUTime()
 end
 
 function plyMeta:GetUTimeStart()
-    return self:GetNWFloat( "CFC_Time_SessionStart", CurTime() )
+    return self:GetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
 end
 
 function plyMeta:GetUTimeSessionTime()
@@ -70,7 +70,6 @@ if SERVER then
     end
 
     hook.Add( "CFC_Time_PlayerInitialTime", "CFC_Time_UtimeCompat", function( ply, isFirstVisit, timeStruct )
-        ply:SetNWFloat( "UTimeStart", CurTime() )
         if not isFirstVisit then return end
 
         logger:debug( "[UtimeCompat] Received PlayerInitialTime hook for first-time player - migrating time!" )
@@ -80,6 +79,10 @@ if SERVER then
         if not totalUtime then return end
 
         timeStruct.add( totalUtime )
+    end )
+
+    hook.Add( "PlayerInitialSpawn", "CFC_Time_UtimeCompat", function( ply )
+        ply:SetNWFloat( "CFC_UTime_Compat_SessionStart", CurTime() )
     end )
 
     hook.Add( "CFC_Time_PlayerTimeUpdated", "CFC_Time_UtimeCompat", function( ply, totalTime )


### PR DESCRIPTION
https://github.com/TeamUlysses/utime/blob/abc8ffb159371f59892ed248d7898ed717ff4bbc/lua/autorun/sv_utime.lua#L30
Should only be set once when the player spawns in

Added convar for
https://github.com/Alexell/apromote_metadmin/blob/ff6fc0c8365f7de1b8e5711fa41baf6e649f9f10/autopromotegui/lua/ulx/xgui/settings/cl_apromote.lua#L8