### PR TITLE
Alternative Quick fix

### DIFF
--- a/lua/autorun/sh_cfc_time_init.lua
+++ b/lua/autorun/sh_cfc_time_init.lua
@@ -3,8 +3,6 @@ require( "logger" )
 CFCTime = {}
 
 CFCTime.Logger = Logger( "CFCTime" )
-CFCTime.Logger:on( "error" ):call( ErrorNoHalt )
-CFCTime.Logger:on( "fatal" ):call( error )
 
 AddCSLuaFile( "cfc_time/shared/config.lua" )
 AddCSLuaFile( "cfc_time/shared/utime_compat.lua" )

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -50,7 +50,7 @@ end )
 
 --[ API Begins Here ]--
 
-function storage:UpdateBatch( batchData )
+function storage:UpdateBatch( batchData, callback )
     if not batchData then return end
     if table.IsEmpty( batchData ) then return end
 
@@ -59,7 +59,7 @@ function storage:UpdateBatch( batchData )
 
         local query = self:Prepare(
             "sessionUpdate",
-            nil,
+            callback,
             data.joined,
             data.departed,
             data.duration,

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -51,15 +51,16 @@ end )
 --[ API Begins Here ]--
 
 function storage:UpdateBatch( batchData, callback )
-    if not batchData then return end
-    if table.IsEmpty( batchData ) then return end
+    if not batchData then return callback() end
+    if table.IsEmpty( batchData ) then return callback() end
+
+    local transaction = storage:InitTransaction()
+    transaction.onSuccess = callback
 
     for sessionID, data in pairs( batchData ) do
-        local transaction = storage:InitTransaction()
-
         local query = self:Prepare(
             "sessionUpdate",
-            callback,
+            nil,
             data.joined,
             data.departed,
             data.duration,
@@ -67,8 +68,9 @@ function storage:UpdateBatch( batchData, callback )
         )
 
         transaction:addQuery( query )
-        transaction:start()
     end
+
+    transaction:start()
 end
 
 function storage:GetTotalTime( steamID, callback )

--- a/lua/cfc_time/server/storage_options/mysql.lua
+++ b/lua/cfc_time/server/storage_options/mysql.lua
@@ -39,8 +39,7 @@ end
 
 function storage.database:onConnectionFailed( err )
     -- TODO: Test this
-    logger:error( "Failed to connect to database!" )
-    logger:fatal( err )
+    error( "CFCTime: Failed to connect to database! '" .. err .. "'" )
 end
 
 hook.Add( "PostGamemodeLoaded", "CFC_Time_DBInit", function()

--- a/lua/cfc_time/server/storage_options/sqlite.lua
+++ b/lua/cfc_time/server/storage_options/sqlite.lua
@@ -12,9 +12,9 @@ end )
 
 --[ API Begins Here ]--
 
-function storage:UpdateBatch( batchData )
-    if not batchData then return end
-    if table.IsEmpty( batchData ) then return end
+function storage:UpdateBatch( batchData, callback )
+    if not batchData then return callback() end
+    if table.IsEmpty( batchData ) then return callback() end
 
     sql.Begin()
 
@@ -24,6 +24,8 @@ function storage:UpdateBatch( batchData )
     end
 
     sql.Commit()
+
+    callback()
 end
 
 function storage:GetTotalTime( steamID, callback )

--- a/lua/cfc_time/server/storage_options/utils/mysql.lua
+++ b/lua/cfc_time/server/storage_options/utils/mysql.lua
@@ -11,7 +11,7 @@ function storage:InitTransaction()
     local transaction = self.database:createTransaction()
 
     transaction.onError = function( _, err )
-        logger:error( err )
+        error( "Transaction error! '" .. err .. "'" )
     end
 
     return transaction
@@ -21,7 +21,7 @@ function storage:InitQuery( rawQuery )
     local query = self.database:query( rawQuery )
 
     query.onError = function( _, err, errQuery )
-        logger:error( err, errQuery )
+        error( "Query error! '" .. err .. "' - " .. errQuery )
     end
 
     return query
@@ -70,7 +70,7 @@ function storage:AddPreparedStatement( name, query )
     local statement = self.database:prepare( query )
 
     statement.onError = function( _, err, errQuery )
-        logger:error( "An error has occured in a prepared statement!", err, errQuery )
+        error( "An error has occured in a prepared statement! '" .. err .. "' - " .. errQuery )
     end
 
     statement.onSuccess = function()

--- a/lua/cfc_time/server/time_tracking.lua
+++ b/lua/cfc_time/server/time_tracking.lua
@@ -175,15 +175,13 @@ function ctime:cleanupPlayer( ply )
     local steamID64 = ply:SteamID64()
 
     if not steamID64 then
-        logger:error( "Player " .. ply:GetName() .. " did not have a steamID64 on disconnect" )
-        return
+        error( "Player " .. ply:GetName() .. " did not have a steamID64 on disconnect" )
     end
 
     logger:debug( "Player " .. ply:GetName() .. " ( " .. steamID64 .. " ) left at " .. now )
 
     if not self.sessions[steamID64] then
-        logger:error( "No pending update for above player, did they leave before database returned?" )
-        return
+        error( "No pending update for above player, did they leave before database returned?" )
     end
 
     self.sessions[steamID64].departed = now

--- a/lua/cfc_time/server/time_tracking.lua
+++ b/lua/cfc_time/server/time_tracking.lua
@@ -70,11 +70,13 @@ function ctime:updateTimes()
         batch[sessionID] = data
 
         local ply = steamIDToPly[steamID]
+
         if IsValid( ply ) then
             local newTotal = totalTimes[steamID] + timeDelta
             totalTimes[steamID] = newTotal
         else
             totalTimes[steamID] = nil
+            data.departed = departed or now
         end
     end
 

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,0 +1,15 @@
+-- https://github.com/CFC-Servers/gm_playerload
+
+local loadQueue = {}
+
+hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function(ply)
+    loadQueue[ply] = true
+end )
+
+hook.Add( "SetupMove", "GM_FullLoadTrigger", function( ply, _, cmd )
+    if not loadQueue[ply] then return end
+    if cmd:IsForced() then return end
+
+    loadQueue[ply] = nil
+    hook.Run( "PlayerFullLoad", ply )
+end )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -2,7 +2,7 @@
 
 local loadQueue = {}
 
-hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function(ply)
+hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function( ply )
     loadQueue[ply] = true
 end )
 


### PR DESCRIPTION
This is an alternative PR to #51 

It tackles the same problem in a different way. I couldn't decide which was better, so I'll make both and see what you folks think.

This version:
- Simplifies the for loop in `ctime:updateTimes()`. It adds a validity check on the Player to catch situations where they left before their session was fully set up
- Adds an additional post-DB loop to untrack the departed players (after their session was saved to the DB) instead of doing it in the primary loop above it
- Adds the `playerload` library natively
- Doesn't track bots
- Uses a full transaction properly in time updates for mysql storage

Check code comments for more contextual info


Tested:
- That basic time updates work for a single player on both mysql and sqlite3
- That the new transaction bulk update works correctly for mqsql
- That both mysql and sqlite3 handle situations where the `PlayerDisconnect` hook runs too early, or not at all for a given player
